### PR TITLE
Add autonomous agent backend and polished animated UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,11 @@
-import os, json, logging
-from typing import List, TypedDict, Optional
+import os
+import json
+import logging
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass, field, asdict
+from typing import Any, Deque, Dict, List, Optional, TypedDict
 
 try:
     import requests
@@ -14,11 +20,94 @@ from flask import Flask, render_template, request, jsonify
 app = Flask(__name__)
 app.logger.setLevel(logging.INFO)
 
+DEFAULT_MODEL = "openai/gpt-oss-120b"
+SESSION_TTL_SECONDS = 45 * 60  # prune idle conversations after 45 minutes
+
 # ---------- Models ----------
 class SearchItem(TypedDict):
     title: str
     url: str
     snippet: str
+
+
+@dataclass
+class ConversationTurn:
+    role: str
+    content: str
+    meta: Dict[str, Any] = field(default_factory=dict)
+    timestamp: float = field(default_factory=time.time)
+
+
+@dataclass
+class ConversationMemory:
+    turns: Deque[ConversationTurn] = field(
+        default_factory=lambda: deque(maxlen=18)
+    )
+    summary: str = ""
+    last_active: float = field(default_factory=time.time)
+
+    def append(self, role: str, content: str, meta: Optional[Dict[str, Any]] = None) -> None:
+        self.turns.append(ConversationTurn(role=role, content=content, meta=meta or {}))
+        self.last_active = time.time()
+
+    @property
+    def turn_count(self) -> int:
+        return len(self.turns)
+
+    def as_messages(self) -> List[Dict[str, str]]:
+        return [
+            {"role": turn.role, "content": turn.content}
+            for turn in self.turns
+        ]
+
+
+@dataclass
+class SearchAnswer:
+    answer: str
+    sources: List[SearchItem] = field(default_factory=list)
+
+
+@dataclass
+class AgentDecision:
+    action: str
+    reason: str
+    mode: str = "autonomous"
+    forced: bool = False
+    search_query: str = ""
+    search_depth: str = "basic"
+    used_search: bool = False
+    search_results: List[SearchItem] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["search_results"] = self.search_results
+        return data
+
+
+@dataclass
+class AgentResult:
+    conversation_id: str
+    text: str
+    decision: AgentDecision
+    memory: ConversationMemory
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "conversation_id": self.conversation_id,
+            "response": self.text,
+            "meta": {
+                "decision": {
+                    key: value
+                    for key, value in self.decision.to_dict().items()
+                    if key != "search_results"
+                },
+                "sources": self.decision.search_results,
+                "memory": {
+                    "summary": self.memory.summary,
+                    "turns": self.memory.turn_count,
+                },
+            },
+        }
 
 # ---------- HTTP helper ----------
 def _post_json(url: str, headers: dict, payload: dict) -> dict:
@@ -68,35 +157,84 @@ def tavily_search(query: str, k: int = 5, depth: str = "basic") -> List[SearchIt
     return items
 
 # ---------- Groq LLM ----------
-def _groq() -> Optional[Groq]:
-    key = os.getenv("GROQ_API_KEY", "")
-    return Groq(api_key=key) if key else None
+_GROQ_CLIENT: Optional[Groq] = None
 
-def generate_ai_response(prompt: str) -> str:  # unchanged pure-LLM path
+
+def _groq() -> Optional[Groq]:
+    """Return a cached Groq client if credentials are available."""
+
+    global _GROQ_CLIENT
+    key = os.getenv("GROQ_API_KEY", "")
+    if not key:
+        return None
+    if _GROQ_CLIENT is None:
+        _GROQ_CLIENT = Groq(api_key=key)
+    return _GROQ_CLIENT
+
+
+def _call_groq(
+    messages: List[Dict[str, str]],
+    *,
+    temperature: float = 0.6,
+    response_format: Optional[Dict[str, str]] = None,
+) -> Optional[str]:
+    """Utility wrapper that safely executes a Groq chat completion."""
+
     client = _groq()
     if not client:
-        return "GROQ_API_KEY is not set on the server – AI mode is unavailable."
-    r = client.chat.completions.create(
-        model="openai/gpt-oss-120b",
-        messages=[
+        return None
+
+    try:
+        params: Dict[str, Any] = {
+            "model": DEFAULT_MODEL,
+            "messages": messages,
+            "temperature": temperature,
+        }
+        if response_format:
+            params["response_format"] = response_format
+        response = client.chat.completions.create(**params)
+    except Exception as exc:  # pragma: no cover - network heavy
+        app.logger.error("Groq error: %s", exc)
+        return None
+
+    message = response.choices[0].message.content if response.choices else ""
+    if not message:
+        return None
+    return message.strip() or None
+
+
+def generate_ai_response(prompt: str) -> str:
+    """Fallback helper that mirrors the legacy behaviour."""
+
+    content = _call_groq(
+        [
             {"role": "system", "content": "You are Boog – concise, helpful."},
             {"role": "user", "content": prompt},
-        ],
-        temperature=0.6,
+        ]
     )
-    return (r.choices[0].message.content or "").strip() or "(No response)"
+    if content is None:
+        return "GROQ_API_KEY is not set on the server – AI mode is unavailable."
+    return content or "(No response)"
 
-def answer_with_web_search(query: str, k: int = 5, depth: str = "basic") -> str:
+
+def answer_with_web_search(
+    query: str,
+    k: int = 5,
+    depth: str = "basic",
+    context: Optional[str] = None,
+) -> SearchAnswer:
     try:
         results = tavily_search(query, k=k, depth=depth)
     except Exception as exc:
         app.logger.error("Tavily error: %s", exc)
-        return "Web search is temporarily unavailable."
+        return SearchAnswer(
+            answer="Web search is temporarily unavailable.",
+            sources=[],
+        )
 
     if not results:
-        return "No results found."
+        return SearchAnswer(answer="No results found.", sources=[])
 
-    # Build grounded prompt
     sources_txt = []
     for i, r in enumerate(results, 1):
         title = r["title"] or r["url"]
@@ -104,30 +242,287 @@ def answer_with_web_search(query: str, k: int = 5, depth: str = "basic") -> str:
             f"[{i}] {title}\nURL: {r['url']}\nSnippet: {r['snippet']}"
         )
     prompt = (
-        "Use the numbered sources to answer. Cite like [1], [2]. "
-        "Only include supported claims; if unclear, say so.\n\n"
+        "Use the numbered sources to answer the user. Cite the sources inline as [1], [2]. "
+        "If the information is insufficient, state the limitations clearly.\n\n"
         f"USER QUESTION:\n{query}\n\nSOURCES:\n" + "\n\n".join(sources_txt)
     )
+    if context:
+        prompt += f"\n\nCONVERSATION CONTEXT:\n{context}"
 
-    client = _groq()
-    if not client:
-        return "GROQ_API_KEY is not set on the server – AI mode is unavailable."
-
-    r = client.chat.completions.create(
-        model="openai/gpt-oss-120b",
-        messages=[
-            {"role": "system", "content": "Ground answers in the sources and cite."},
+    answer = _call_groq(
+        [
+            {"role": "system", "content": "Ground answers in the supplied sources and cite them."},
             {"role": "user", "content": prompt},
         ],
         temperature=0.3,
     )
-    answer = (r.choices[0].message.content or "").strip()
 
-    links = "\n".join(
-        f"- [{i}] {it['title'] or it['url']} — {it['url']}"
-        for i, it in enumerate(results, 1)
-    )
-    return f"{answer}\n\n---\n**Sources (links):**\n{links}"
+    if answer is None:
+        answer = "Unable to access the language model right now."
+
+    return SearchAnswer(answer=answer, sources=results)
+
+
+def _format_recent_dialogue(memory: ConversationMemory, limit: int = 6) -> str:
+    recent: List[ConversationTurn] = list(memory.turns)[-limit:]
+    formatted = []
+    for turn in recent:
+        if turn.role not in {"user", "assistant"}:
+            continue
+        speaker = "User" if turn.role == "user" else "Boog"
+        formatted.append(f"{speaker}: {turn.content}")
+    return "\n".join(formatted)
+
+
+class BoogAgent:
+    """Stateful agent that manages conversation memory and tool use."""
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, ConversationMemory] = {}
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    def _get_memory(self, session_id: str) -> ConversationMemory:
+        key = session_id or "default"
+        with self._lock:
+            memory = self._sessions.get(key)
+            if memory is None:
+                memory = ConversationMemory()
+                self._sessions[key] = memory
+        return memory
+
+    def _prune_sessions(self) -> None:
+        now = time.time()
+        with self._lock:
+            expired = [
+                session_id
+                for session_id, memory in self._sessions.items()
+                if now - memory.last_active > SESSION_TTL_SECONDS
+            ]
+            for session_id in expired:
+                self._sessions.pop(session_id, None)
+
+    # ------------------------------------------------------------------
+    def _heuristic_decision(self, user_input: str, default_depth: str) -> AgentDecision:
+        lowered = user_input.lower()
+        factual_keywords = (
+            "latest",
+            "recent",
+            "update",
+            "news",
+            "current",
+            "today",
+            "official",
+            "evidence",
+            "statistics",
+            "data",
+            "http://",
+            "https://",
+        )
+        question_words = ("who", "what", "when", "where", "why", "how")
+        if any(keyword in lowered for keyword in factual_keywords) or (
+            "?" in user_input and lowered.split()[:1] and lowered.split()[0] in question_words
+        ):
+            return AgentDecision(
+                action="search_and_respond",
+                reason="Heuristic: the query looks factual or time-sensitive.",
+                search_query=user_input,
+                search_depth=default_depth,
+                used_search=True,
+            )
+        return AgentDecision(
+            action="respond",
+            reason="Heuristic: the request appears conversational or creative.",
+            search_depth=default_depth,
+        )
+
+    def _autonomous_decision(
+        self,
+        memory: ConversationMemory,
+        user_input: str,
+        default_depth: str,
+    ) -> AgentDecision:
+        payload = {
+            "summary": memory.summary,
+            "recent_messages": [
+                {"role": turn.role, "content": turn.content}
+                for turn in list(memory.turns)[-6:]
+            ],
+            "user_input": user_input,
+        }
+
+        response_text = _call_groq(
+            [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are the reasoning module for Boog, an autonomous assistant. "
+                        "Decide whether to respond directly or to perform web search first. "
+                        "Return strictly valid JSON with keys 'action', 'reason', 'search_query', 'search_depth'. "
+                        "Valid actions: 'respond', 'search', 'search_and_respond'. "
+                        "Choose a search action when the user needs external facts, citations, or recent information."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": json.dumps(payload, ensure_ascii=False),
+                },
+            ],
+            temperature=0.0,
+            response_format={"type": "json_object"},
+        )
+
+        if response_text:
+            try:
+                data = json.loads(response_text)
+                action = str(data.get("action", "respond")).strip().lower()
+                reason = str(data.get("reason", "")).strip() or "Autonomous decision."
+                search_query = str(data.get("search_query", "")).strip() or user_input
+                depth = str(data.get("search_depth", default_depth)).strip() or default_depth
+                if action not in {"respond", "search", "search_and_respond"}:
+                    action = "respond"
+                decision = AgentDecision(
+                    action=action if action != "search" else "search_and_respond",
+                    reason=reason,
+                    mode="autonomous",
+                    search_query=search_query,
+                    search_depth=depth if depth in {"basic", "advanced"} else default_depth,
+                    used_search=action in {"search", "search_and_respond"},
+                )
+                return decision
+            except json.JSONDecodeError:
+                app.logger.debug("Failed to parse autonomous decision JSON: %s", response_text)
+
+        return self._heuristic_decision(user_input, default_depth)
+
+    def _build_context(self, memory: ConversationMemory) -> str:
+        parts: List[str] = []
+        if memory.summary:
+            parts.append(f"Summary: {memory.summary}")
+        recent = _format_recent_dialogue(memory)
+        if recent:
+            parts.append("Recent dialogue:\n" + recent)
+        return "\n\n".join(parts)
+
+    def _respond_with_memory(self, memory: ConversationMemory) -> str:
+        messages: List[Dict[str, str]] = [
+            {
+                "role": "system",
+                "content": (
+                    "You are Boog, an autonomous, thoughtful AI cat assistant. "
+                    "Answer using the conversation context. Be proactive, concise yet thorough, and cite prior search results if referenced."
+                ),
+            }
+        ]
+        if memory.summary:
+            messages.append(
+                {
+                    "role": "system",
+                    "content": f"Conversation summary so far: {memory.summary}",
+                }
+            )
+        messages.extend(memory.as_messages())
+
+        response = _call_groq(messages, temperature=0.55)
+        if response is not None:
+            return response
+
+        latest_user = next(
+            (turn.content for turn in reversed(memory.turns) if turn.role == "user"),
+            "",
+        )
+        return generate_ai_response(latest_user) if latest_user else "I am unable to respond right now."
+
+    def _maybe_summarize(self, memory: ConversationMemory) -> None:
+        if memory.turn_count < memory.turns.maxlen:
+            return
+
+        transcript = "\n".join(
+            f"{turn.role.upper()}: {turn.content}"
+            for turn in memory.turns
+        )
+        summary = _call_groq(
+            [
+                {
+                    "role": "system",
+                    "content": (
+                        "Summarise the following chat transcript in 3 concise bullet points. "
+                        "Focus on decisions, user preferences, and pending tasks."
+                    ),
+                },
+                {"role": "user", "content": transcript},
+            ],
+            temperature=0.2,
+        )
+        if summary:
+            memory.summary = summary
+            while memory.turn_count > memory.turns.maxlen // 2:
+                memory.turns.popleft()
+
+    # ------------------------------------------------------------------
+    def handle_message(
+        self,
+        session_id: str,
+        user_input: str,
+        *,
+        forced_mode: Optional[str] = None,
+        search_depth: str = "basic",
+    ) -> AgentResult:
+        memory = self._get_memory(session_id)
+        memory.append("user", user_input)
+
+        normalized_mode = (forced_mode or "").strip().lower()
+        if normalized_mode in {"web", "web-search", "search"}:
+            decision = AgentDecision(
+                action="search_and_respond",
+                reason="User enabled Web Search mode.",
+                mode="user_web",
+                forced=True,
+                search_query=user_input,
+                search_depth=search_depth,
+                used_search=True,
+            )
+        else:
+            decision = self._autonomous_decision(memory, user_input, search_depth)
+
+        context = self._build_context(memory)
+        if decision.used_search:
+            search_query = decision.search_query or user_input
+            answer = answer_with_web_search(
+                search_query,
+                k=5,
+                depth=decision.search_depth,
+                context=context,
+            )
+            decision.search_results = answer.sources
+            response_text = answer.answer
+            if not decision.search_results:
+                decision.reason += " (Search returned no results.)"
+        else:
+            response_text = self._respond_with_memory(memory)
+
+        memory.append(
+            "assistant",
+            response_text,
+            meta={
+                "decision": decision.action,
+                "used_search": decision.used_search,
+                "forced": decision.forced,
+            },
+        )
+
+        self._maybe_summarize(memory)
+        self._prune_sessions()
+
+        return AgentResult(
+            conversation_id=session_id or "default",
+            text=response_text,
+            decision=decision,
+            memory=memory,
+        )
+
+
+AGENT = BoogAgent()
 
 
 # ---------- Flask Routes ----------------------------------------------------
@@ -140,18 +535,33 @@ def index():
 def chat():
     payload = request.get_json(silent=True) or {}
     user_input: str = (payload.get("message") or "").strip()
-    mode: str = (payload.get("mode") or "ai").lower()  # "ai" | "web"
+    mode: str = (payload.get("mode") or "ai").lower()
+    session_id: str = (
+        payload.get("session_id")
+        or request.cookies.get("boog-session-id", "")
+        or request.remote_addr
+        or "default"
+    )
 
     if not user_input:
-        return jsonify(response="Please provide a message.")
+        return jsonify({
+            "conversation_id": session_id,
+            "response": "Please provide a message.",
+            "meta": {"error": True},
+        })
 
-    if mode in ("web", "web-search", "search"):
-        # You can flip to depth="advanced" for tougher queries (costs 2 credits).
-        resp = answer_with_web_search(user_input, k=5, depth="basic")
-    else:
-        resp = generate_ai_response(user_input)
+    search_depth = str(payload.get("search_depth") or "basic").lower()
+    if search_depth not in {"basic", "advanced"}:
+        search_depth = "basic"
 
-    return jsonify(response=resp)
+    result = AGENT.handle_message(
+        session_id,
+        user_input,
+        forced_mode=mode,
+        search_depth=search_depth,
+    )
+
+    return jsonify(result.to_dict())
 
 
 # ---------- Entrypoint ------------------------------------------------------

--- a/static/boog.css
+++ b/static/boog.css
@@ -14,6 +14,12 @@
   --code-bg: rgba(0, 0, 0, 0.05);
   --ok: #10b981;
   --danger: #ef4444;
+  --glass-bg: rgba(255, 255, 255, 0.68);
+  --pill-bg: rgba(255, 255, 255, 0.65);
+  --pill-border: rgba(99, 102, 241, 0.25);
+  --meta-bg: rgba(255, 255, 255, 0.9);
+  --meta-border: rgba(99, 102, 241, 0.2);
+  --glow-accent: rgba(99, 102, 241, 0.4);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -27,6 +33,12 @@
     --text-secondary: #9ca3af;
     --border-color: rgba(255, 255, 255, 0.1);
     --code-bg: rgba(255, 255, 255, 0.05);
+    --glass-bg: rgba(17, 24, 39, 0.75);
+    --pill-bg: rgba(30, 41, 59, 0.65);
+    --pill-border: rgba(129, 140, 248, 0.3);
+    --meta-bg: rgba(30, 41, 59, 0.85);
+    --meta-border: rgba(129, 140, 248, 0.35);
+    --glow-accent: rgba(129, 140, 248, 0.45);
   }
 }
 
@@ -40,42 +52,272 @@ body {
   display: flex;
   flex-direction: column;
   overflow-x: hidden;
+  position: relative;
 }
 
 body::before {
   content: '';
   position: fixed; inset: 0;
   background: var(--bg-overlay);
-  -webkit-backdrop-filter: blur(20px) saturate(180%);
-  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(24px) saturate(200%);
+  backdrop-filter: blur(24px) saturate(200%);
+  z-index: -2;
+}
+
+.aurora {
+  position: fixed;
+  inset: -20%;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.25), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(99, 102, 241, 0.25), transparent 50%),
+    radial-gradient(circle at 10% 90%, rgba(236, 72, 153, 0.2), transparent 55%);
+  opacity: 0.9;
+  filter: blur(80px);
+  animation: auroraShift 18s ease-in-out infinite alternate;
+  z-index: -3;
+  pointer-events: none;
+}
+
+.glow-orbs {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
   z-index: -1;
 }
 
-.container {
-  width: 100%; max-width: 700px; margin: 0 auto;
-  padding: 2rem 1.5rem 9rem;
-  flex: 1; display: flex; flex-direction: column; position: relative;
+.glow-orbs .orb {
+  position: absolute;
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.55), transparent 70%);
+  mix-blend-mode: screen;
+  animation: floatOrb 22s ease-in-out infinite;
 }
 
-.header { text-align: center; margin-bottom: 2rem; animation: fadeInUp 0.8s ease-out; }
-h1 { font-size: 3rem; font-weight: 700; color: var(--text-main); margin-bottom: 0.5rem; text-shadow: 0 2px 10px rgba(0,0,0,.1); }
-.subtitle { color: var(--text-secondary); font-size: 1.1rem; font-weight: 300; margin-bottom: 1.5rem; }
+.glow-orbs .orb-one { top: 12%; left: 8%; animation-delay: 0s; }
+.glow-orbs .orb-two { bottom: 18%; right: 10%; animation-delay: 4s; }
+.glow-orbs .orb-three { top: 40%; right: 25%; width: 260px; height: 260px; animation-delay: 8s; }
 
-#chat { flex: 1; display: flex; flex-direction: column; gap: 1rem; overflow-y: auto; padding-right: .5rem; scroll-behavior: smooth; }
+.container {
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2.25rem 1.75rem 9.5rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  z-index: 1;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 1.75rem;
+  animation: fadeInUp 0.8s ease-out;
+}
+h1 {
+  font-size: 3.1rem;
+  font-weight: 700;
+  color: var(--text-main);
+  margin-bottom: 0.6rem;
+  text-shadow: 0 18px 45px rgba(99, 102, 241, 0.22);
+}
+.subtitle {
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  font-weight: 300;
+  margin: 0 auto 1.3rem;
+  max-width: 480px;
+}
+.subtitle a {
+  color: var(--accent);
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+.subtitle a:hover,
+.subtitle a:focus {
+  color: var(--accent-hover);
+}
+
+.status-bar {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  background: var(--pill-bg);
+  border: 1px solid var(--pill-border);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  box-shadow: 0 12px 30px rgba(99, 102, 241, 0.12);
+  transition: all 0.3s ease;
+}
+
+.status-pill::before {
+  content: '';
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: var(--glow-accent);
+  box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.35);
+  transition: all 0.4s ease;
+}
+
+.status-pill[data-state="search"]::before {
+  background: var(--accent);
+  box-shadow: 0 0 0 6px rgba(99, 102, 241, 0.15);
+}
+
+.status-pill[data-state="search"] {
+  background: linear-gradient(135deg, rgba(99,102,241,.95), rgba(76, 81, 191, .95));
+  color: #fff;
+  border-color: rgba(99, 102, 241, 0.4);
+  box-shadow: 0 16px 36px rgba(99, 102, 241, 0.45);
+}
+
+.status-pill.waiting::before {
+  animation: pulseDot 1.8s ease-in-out infinite;
+}
+
+.status-pill.secondary {
+  background: var(--glass-bg);
+  border-color: rgba(148, 163, 184, 0.25);
+  box-shadow: 0 12px 30px rgba(148, 163, 184, 0.12);
+}
+
+.status-pill.has-summary {
+  color: var(--text-main);
+}
+
+#chat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+  scroll-behavior: smooth;
+}
 #chat::-webkit-scrollbar { width: 6px; }
 #chat::-webkit-scrollbar-thumb { background: var(--border-color); border-radius: 3px; }
 
 .msg {
-  max-width: 80%; padding: 1rem 1.5rem; border-radius: 20px; line-height: 1.6;
-  word-wrap: break-word; white-space: pre-wrap; overflow-wrap: anywhere; position: relative;
-  animation: messageSlideIn .4s ease-out; box-shadow: var(--shadow);
-  -webkit-backdrop-filter: blur(20px) saturate(180%);
-  backdrop-filter: blur(20px) saturate(180%);
+  max-width: 80%;
+  padding: 1rem 1.5rem;
+  border-radius: 22px;
+  line-height: 1.6;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  position: relative;
+  animation: messageSlideIn 0.45s ease-out;
+  box-shadow: 0 22px 45px rgba(15, 23, 42, 0.12);
+  -webkit-backdrop-filter: blur(24px) saturate(185%);
+  backdrop-filter: blur(24px) saturate(185%);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  overflow: hidden;
 }
-.user { align-self: flex-end; background: var(--user-bg); color: #fff; border-bottom-right-radius: 8px; transition: transform .2s ease; }
-.user:hover { transform: translateY(-2px); }
-.boog { align-self: flex-start; background: var(--boog-bg); color: var(--text-main); font-weight: 500; border-bottom-left-radius: 8px; transition: transform .2s ease; border: 1px solid var(--border-color); }
-.boog:hover { transform: translateY(-2px); }
+
+.msg::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.12), transparent 60%);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+.msg:hover::after {
+  opacity: 0.6;
+}
+
+.user {
+  align-self: flex-end;
+  background: var(--user-bg);
+  color: #fff;
+  border-bottom-right-radius: 10px;
+  box-shadow: 0 18px 35px rgba(99, 102, 241, 0.25);
+}
+
+.user:hover {
+  transform: translateY(-3px) scale(1.01);
+}
+
+.boog {
+  align-self: flex-start;
+  background: var(--boog-bg);
+  color: var(--text-main);
+  font-weight: 500;
+  border-bottom-left-radius: 10px;
+  border: 1px solid var(--border-color);
+  box-shadow: 0 20px 38px rgba(148, 163, 184, 0.2);
+}
+
+.boog:hover {
+  transform: translateY(-3px);
+}
+
+.agent-meta {
+  margin-top: 0.85rem;
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  background: var(--meta-bg);
+  border: 1px solid var(--meta-border);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.08);
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.agent-reason {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text-main);
+}
+
+.agent-sources {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.agent-sources a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  transition: color 0.2s ease;
+}
+
+.agent-sources a::after {
+  content: '↗';
+  font-size: 0.75rem;
+}
+
+.agent-sources a:hover,
+.agent-sources a:focus {
+  color: var(--accent-hover);
+}
+
+.fade-in {
+  animation: fadeIn 0.45s ease-out both;
+}
 
 .boog h1,.boog h2,.boog h3,.boog h4,.boog h5{margin:1rem 0 .5rem;font-weight:600;color:var(--text-main)}
 .boog p{margin:.5rem 0}
@@ -84,57 +326,99 @@ h1 { font-size: 3rem; font-weight: 700; color: var(--text-main); margin-bottom: 
 .boog code{font-family:'JetBrains Mono','Fira Code',monospace;font-size:.9rem;font-weight:500}
 .boog blockquote{border-left:4px solid var(--accent);margin:1rem 0;padding-left:1rem;font-style:italic;opacity:.8}
 
-.typing-indicator { display: flex; align-items: center; gap: .5rem; padding: .5rem 0; }
+.typing-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 0.75rem;
+  background: rgba(255, 255, 255, 0.55);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  box-shadow: 0 12px 24px rgba(148, 163, 184, 0.18);
+}
+.typing-indicator span { font-weight: 600; letter-spacing: .02em; }
 .typing-dots { display: flex; gap: 4px; }
 .typing-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--text-secondary); animation: typingBounce 1.4s infinite; }
 .typing-dot:nth-child(2){animation-delay:.2s} .typing-dot:nth-child(3){animation-delay:.4s}
 @keyframes typingBounce{0%,60%,100%{transform:translateY(0)}30%{transform:translateY(-10px)}}
 
+@keyframes auroraShift {
+  0% { transform: translate3d(-2%, -2%, 0) scale(1); opacity: 0.85; }
+  50% { transform: translate3d(1%, 2%, 0) scale(1.05); opacity: 1; }
+  100% { transform: translate3d(3%, -1%, 0) scale(1.08); opacity: 0.9; }
+}
+
+@keyframes floatOrb {
+  0%, 100% { transform: translate3d(0, 0, 0) scale(1); opacity: 0.6; }
+  50% { transform: translate3d(12px, -18px, 0) scale(1.05); opacity: 0.85; }
+}
+
+@keyframes pulseDot {
+  0%, 100% { transform: scale(0.9); opacity: 0.8; }
+  50% { transform: scale(1.1); opacity: 1; }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
 .input-container {
   position: fixed; bottom: 0; left: 0; right: 0;
-  padding: 1.5rem; display: flex; justify-content: center;
-  background: linear-gradient(to top, var(--bg-overlay) 70%, transparent);
-  -webkit-backdrop-filter: blur(20px) saturate(180%);
-  backdrop-filter: blur(20px) saturate(180%);
+  padding: 1.6rem 1.5rem 1.9rem; display: flex; justify-content: center;
+  background: linear-gradient(to top, var(--bg-overlay) 75%, transparent);
+  -webkit-backdrop-filter: blur(26px) saturate(200%);
+  backdrop-filter: blur(26px) saturate(200%);
+  z-index: 2;
 }
 .input-bar {
   display: flex; align-items: center; gap: .5rem;
   width: 100%; max-width: 700px;
-  background: var(--bg-alt);
-  -webkit-backdrop-filter: blur(20px) saturate(180%);
-  backdrop-filter: blur(20px) saturate(180%);
-  border: 2px solid var(--border-color); border-radius: 25px;
-  padding: .5rem .5rem .5rem .75rem;
-  box-shadow: var(--shadow-hover); transition: all .3s ease;
+  background: var(--glass-bg);
+  -webkit-backdrop-filter: blur(28px) saturate(180%);
+  backdrop-filter: blur(28px) saturate(180%);
+  border: 2px solid rgba(255,255,255,0.25);
+  border-radius: 28px;
+  padding: .55rem .55rem .55rem .85rem;
+  box-shadow: 0 24px 45px rgba(15,23,42,.15);
+  transition: all .35s ease;
 }
-.input-bar:focus-within { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(99,102,241,.1), var(--shadow-hover); transform: translateY(-2px); }
+.input-bar:focus-within {
+  border-color: rgba(99,102,241,.45);
+  box-shadow: 0 18px 45px rgba(99,102,241,.25);
+  transform: translateY(-3px) scale(1.01);
+}
 
 .input-bar input[type='text']{
   flex:1; border:none; outline:none; background:transparent;
   font-size:1rem; font-family:'Inter',sans-serif; color:var(--text-main);
-  padding:.5rem 1rem; font-weight:400;
+  padding:.55rem 1rem; font-weight:400;
+  transition: color .2s ease;
 }
-.input-bar input::placeholder{color:var(--text-secondary);font-weight:300}
+.input-bar input::placeholder{color:var(--text-secondary);font-weight:300;transition:color .2s ease;}
+.input-bar:focus-within input::placeholder{color:rgba(99,102,241,.6)}
 
 /* Mode button (magnifying glass) */
 .mode-button {
   display: inline-flex; align-items: center; justify-content: center;
   width: 40px; height: 40px;
   border-radius: 50%;
-  border: 1.5px solid var(--border-color);
-  background: transparent;
+  border: 1.5px solid rgba(148,163,184,.3);
+  background: rgba(255,255,255,0.65);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: all .2s ease;
+  transition: all .25s ease;
   position: relative;
+  box-shadow: 0 12px 24px rgba(15,23,42,.12);
 }
-.mode-button:hover { color: var(--text-main); border-color: var(--accent); box-shadow: 0 4px 12px rgba(99,102,241,.15); transform: translateY(-1px); }
+.mode-button:hover { color: var(--text-main); border-color: rgba(99,102,241,.45); box-shadow: 0 14px 28px rgba(99,102,241,.25); transform: translateY(-2px); }
 .mode-button:active { transform: translateY(0); }
 .mode-button.active {
   background: var(--accent);
   color: #fff;
   border-color: var(--accent);
-  box-shadow: 0 6px 16px rgba(99,102,241,.35);
+  box-shadow: 0 16px 32px rgba(99,102,241,.45);
 }
 .mode-badge {
   position: absolute; bottom: -6px; right: -6px;
@@ -145,11 +429,22 @@ h1 { font-size: 3rem; font-weight: 700; color: var(--text-main); margin-bottom: 
 
 .send-button {
   display:flex;align-items:center;justify-content:center;
-  width:40px;height:40px;padding:0;background:var(--accent);color:#fff;border:none;border-radius:50%;
-  cursor:pointer;transition:all .3s ease;box-shadow:0 4px 12px rgba(99,102,241,.3);
+  width:44px;height:44px;padding:0;background:var(--accent);color:#fff;border:none;border-radius:50%;
+  cursor:pointer;transition:all .3s ease;box-shadow:0 16px 32px rgba(99,102,241,.4);
+  position: relative;
+  overflow: hidden;
 }
-.send-button:hover:not(:disabled){background:var(--accent-hover);transform:scale(1.05);box-shadow:0 6px 16px rgba(99,102,241,.4)}
-.send-button:active{transform:scale(.95)}
+.send-button::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top, rgba(255,255,255,.35), transparent 60%);
+  opacity: 0;
+  transition: opacity .3s ease;
+}
+.send-button:hover:not(:disabled){background:var(--accent-hover);transform:translateY(-2px) scale(1.05);box-shadow:0 20px 36px rgba(99,102,241,.45);}
+.send-button:hover::after{opacity:.6;}
+.send-button:active{transform:translateY(0) scale(.96)}
 .send-button:disabled{background:var(--text-secondary);cursor:not-allowed;transform:none;box-shadow:none}
 .send-button.loading{animation:spin 1s linear infinite}
 @keyframes spin{from{transform:rotate(0)}to{transform:rotate(360deg)}}
@@ -157,16 +452,27 @@ h1 { font-size: 3rem; font-weight: 700; color: var(--text-main); margin-bottom: 
 @keyframes fadeInUp{from{opacity:0;transform:translateY(30px)}to{opacity:1;transform:translateY(0)}}
 @keyframes messageSlideIn{from{opacity:0;transform:translateY(20px) scale(.95)}to{opacity:1;transform:translateY(0) scale(1)}}
 
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+  .aurora, .glow-orbs .orb { display: none !important; }
+}
+
 @media (max-width:768px){
   .container{padding:1.5rem 1rem 8rem;max-width:100%}
   h1{font-size:2.5rem}
   .msg{max-width:90%;padding:.875rem 1.25rem}
+  .status-pill{font-size:.68rem;padding:.35rem .75rem}
 }
 @media (max-width:480px){
   .container{padding:1rem .75rem 7rem}
   h1{font-size:2rem}
   .msg{max-width:95%;padding:.75rem 1rem}
   .input-container{padding:1rem}
+  .status-bar{gap:.5rem}
 }
 
 *:focus { outline: 2px solid var(--accent); outline-offset: 2px; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,6 +34,13 @@
 <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" async></script>
 
 <body>
+  <div class="aurora" aria-hidden="true"></div>
+  <div class="glow-orbs" aria-hidden="true">
+    <span class="orb orb-one"></span>
+    <span class="orb orb-two"></span>
+    <span class="orb orb-three"></span>
+  </div>
+
   <div class="container">
     <div class="header">
       <h1>Boog 😼</h1>
@@ -44,7 +51,10 @@
           Roberto Pillitteri
         </a>
       </p>
-      <!-- Mode selector removed -->
+      <div class="status-bar" role="status" aria-live="polite">
+        <span class="status-pill" id="agentModeChip" data-state="chat">Autonomous mode</span>
+        <span class="status-pill secondary" id="memoryChip">Memory warming up</span>
+      </div>
     </div>
 
     <div id="chat" role="log" aria-live="polite" aria-label="Chat messages"></div>
@@ -97,9 +107,28 @@
     const messageInput = document.getElementById('message');
     const sendBtn = document.getElementById('sendBtn');
     const webToggle = document.getElementById('webToggle');
+    const agentModeChip = document.getElementById('agentModeChip');
+    const memoryChip = document.getElementById('memoryChip');
 
     let isTyping = false;
-    let currentMode = 'ai'; // default
+    let currentMode = 'ai';
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    const conversationId = (() => {
+      const storageKey = 'boog-conversation-id';
+      try {
+        let id = localStorage.getItem(storageKey);
+        if (!id) {
+          id = typeof crypto !== 'undefined' && crypto.randomUUID
+            ? crypto.randomUUID()
+            : `conv-${Date.now().toString(36)}`;
+          localStorage.setItem(storageKey, id);
+        }
+        return id;
+      } catch (_) {
+        return `conv-${Date.now().toString(36)}`;
+      }
+    })();
 
     document.addEventListener('keydown', (e) => {
       if (e.altKey && (e.key === 'w' || e.key === 'W')) {
@@ -110,7 +139,13 @@
 
     sendBtn.addEventListener('click', sendMessage);
     messageInput.addEventListener('keydown', handleKeyPress);
+    messageInput.addEventListener('input', autoResizeInput);
     webToggle.addEventListener('click', toggleWebMode);
+
+    function autoResizeInput() {
+      this.style.height = 'auto';
+      this.style.height = Math.min(this.scrollHeight, 140) + 'px';
+    }
 
     function toggleWebMode() {
       const isActive = webToggle.classList.toggle('active');
@@ -122,11 +157,16 @@
       webToggle.title = isActive
         ? 'Web Search: ON (Alt+W to turn off)'
         : 'Toggle Web Search mode (Alt+W)';
+
+      if (agentModeChip) {
+        agentModeChip.dataset.state = isActive ? 'search' : 'chat';
+        agentModeChip.textContent = isActive ? 'Manual web search ready' : 'Autonomous mode';
+      }
     }
 
-    function handleKeyPress(e) {
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault();
+    function handleKeyPress(event) {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
         sendMessage();
       }
     }
@@ -135,7 +175,7 @@
       const indicator = document.createElement('div');
       indicator.className = 'typing-indicator';
       indicator.innerHTML = `
-        <span>BoogGPT is typing</span>
+        <span>BoogGPT is thinking</span>
         <div class="typing-dots">
           <div class="typing-dot"></div>
           <div class="typing-dot"></div>
@@ -146,41 +186,42 @@
     }
 
     function typeResponse(element, markdownText) {
-  return new Promise((resolve) => {
-    // Adaptive chunking based on message size
-    const len = markdownText.length;
-    const chunkSize = len > 1500 ? 40 : len > 700 ? 24 : len > 250 ? 12 : 6;
+      return new Promise((resolve) => {
+        const len = markdownText.length;
+        const chunkSize = len > 1500 ? 48 : len > 700 ? 28 : len > 250 ? 14 : 7;
 
-    let index = 0;
-    element.textContent = '';
+        let index = 0;
+        element.textContent = '';
 
-    // Use requestAnimationFrame for smoothness
-    function tick() {
-      // Append a chunk of raw text quickly
-      const nextIndex = Math.min(index + chunkSize, len);
-      element.textContent += markdownText.slice(index, nextIndex);
-      index = nextIndex;
-      scrollToBottom();
+        function tick() {
+          const nextIndex = Math.min(index + chunkSize, len);
+          element.textContent += markdownText.slice(index, nextIndex);
+          index = nextIndex;
+          scrollToBottom();
 
-      if (index < len) {
-        requestAnimationFrame(tick);
-      } else {
-        // Once done, render Markdown in one go (fastest), sanitize, then MathJax
-        const html = marked.parse(markdownText);
-        element.innerHTML = DOMPurify.sanitize(html);
-        scrollToBottom();
-
-        // Typeset only this message node for speed
-        if (window.MathJax?.typesetPromise) {
-          MathJax.typesetPromise([element]).catch(err => console.error(err.message));
+          if (index < len && !prefersReducedMotion) {
+            requestAnimationFrame(tick);
+          } else if (index < len) {
+            element.textContent = markdownText;
+            finalize();
+          } else {
+            finalize();
+          }
         }
-        resolve();
-      }
-    }
-    requestAnimationFrame(tick);
-  });
-}
 
+        function finalize() {
+          const html = marked.parse(markdownText);
+          element.innerHTML = DOMPurify.sanitize(html);
+          scrollToBottom();
+          if (window.MathJax?.typesetPromise) {
+            MathJax.typesetPromise([element]).catch(err => console.error(err.message));
+          }
+          resolve();
+        }
+
+        requestAnimationFrame(tick);
+      });
+    }
 
     function appendUserMessage(text) {
       const div = document.createElement('div');
@@ -191,16 +232,87 @@
       scrollToBottom();
     }
 
-    function appendBotMessage(text) {
+    function appendBotMessage(text, meta) {
       const div = document.createElement('div');
       div.className = 'msg boog';
       div.setAttribute('role', 'assistant');
       chat.appendChild(div);
       const messageWithCat = '🐱 ' + text;
-      return typeResponse(div, messageWithCat);
+      return typeResponse(div, messageWithCat).then(() => renderMeta(div, meta));
     }
 
-    function scrollToBottom() { chat.scrollTop = chat.scrollHeight; }
+    function renderMeta(container, meta) {
+      if (!meta) return;
+
+      const extras = document.createElement('div');
+      extras.className = 'agent-meta fade-in';
+
+      if (meta.decision?.reason) {
+        const reason = document.createElement('p');
+        reason.className = 'agent-reason';
+        reason.textContent = meta.decision.reason;
+        extras.appendChild(reason);
+      }
+
+      if (Array.isArray(meta.sources) && meta.sources.length) {
+        const list = document.createElement('ul');
+        list.className = 'agent-sources';
+        meta.sources.slice(0, 4).forEach((source, index) => {
+          if (!source?.url) return;
+          const item = document.createElement('li');
+          const link = document.createElement('a');
+          link.href = source.url;
+          link.target = '_blank';
+          link.rel = 'noopener noreferrer';
+          link.textContent = `[${index + 1}] ${source.title || source.url}`;
+          item.appendChild(link);
+          list.appendChild(item);
+        });
+        if (list.childElementCount) {
+          extras.appendChild(list);
+        }
+      }
+
+      if (extras.childElementCount) {
+        container.appendChild(extras);
+      }
+    }
+
+    function updateStatus(meta) {
+      if (agentModeChip && meta?.decision) {
+        const { used_search, forced, reason } = meta.decision;
+        let label = forced ? 'Manual web search' : 'Autonomous mode';
+        label += used_search ? ' · Search' : ' · Conversation';
+        agentModeChip.textContent = label;
+        agentModeChip.dataset.state = used_search ? 'search' : 'chat';
+        if (reason) {
+          agentModeChip.title = reason;
+        } else {
+          agentModeChip.removeAttribute('title');
+        }
+      }
+
+      if (memoryChip && meta?.memory) {
+        const turns = meta.memory.turns ?? 0;
+        const summary = (meta.memory.summary || '').trim();
+        if (turns > 1) {
+          memoryChip.textContent = `Memory active · ${turns} turns`;
+        } else {
+          memoryChip.textContent = 'Memory warming up';
+        }
+        if (summary) {
+          memoryChip.classList.add('has-summary');
+          memoryChip.title = summary;
+        } else {
+          memoryChip.classList.remove('has-summary');
+          memoryChip.removeAttribute('title');
+        }
+      }
+    }
+
+    function scrollToBottom() {
+      chat.scrollTop = chat.scrollHeight;
+    }
 
     function setLoading(loading) {
       isTyping = loading;
@@ -208,11 +320,20 @@
       sendBtn.classList.toggle('loading', loading);
       messageInput.disabled = loading;
       webToggle.disabled = loading;
+      if (agentModeChip) {
+        agentModeChip.classList.toggle('waiting', loading);
+      }
       if (loading) {
         sendBtn.setAttribute('aria-label', 'Sending message...');
       } else {
         sendBtn.setAttribute('aria-label', 'Send message');
       }
+    }
+
+    async function renderAssistantResponse(container, message, meta) {
+      await typeResponse(container, '🐱 ' + (message ?? 'No response.'));
+      renderMeta(container, meta);
+      updateStatus(meta);
     }
 
     async function sendMessage() {
@@ -236,31 +357,34 @@
         const response = await fetch('/chat', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ message, mode: currentMode })
+          body: JSON.stringify({
+            message,
+            mode: currentMode,
+            session_id: conversationId,
+          }),
         });
 
         if (!response.ok) throw new Error('Network response was not ok');
 
         const data = await response.json();
-
         botMsgDiv.removeChild(typingIndicator);
-        await typeResponse(botMsgDiv, '🐱 ' + (data.response ?? 'No response.'));
+        await renderAssistantResponse(botMsgDiv, data.response, data.meta);
       } catch (error) {
         console.error('Error:', error);
         botMsgDiv.removeChild(typingIndicator);
         await typeResponse(botMsgDiv, '🐱 ⚠️ Oops! Something went wrong. Please try again in a moment.');
+        if (agentModeChip) {
+          agentModeChip.dataset.state = 'chat';
+          agentModeChip.textContent = 'Connection issue';
+          agentModeChip.title = 'Failed to reach the server';
+        }
       } finally {
         setLoading(false);
       }
     }
 
     window.addEventListener('load', () => {
-      setTimeout(() => { appendBotMessage('Hey there! I\'m Boog!'); }, 500);
-    });
-
-    messageInput.addEventListener('input', function () {
-      this.style.height = 'auto';
-      this.style.height = Math.min(this.scrollHeight, 120) + 'px';
+      setTimeout(() => { appendBotMessage('Hey there! I\'m Boog!'); }, 450);
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- introduce a stateful `BoogAgent` that maintains conversation memory, makes autonomous tool decisions, and orchestrates Tavily search plus Groq responses with rich metadata
- update the `/chat` endpoint to track per-session conversations, validate inputs, and return structured agent state for the client
- refresh the chat UI with animated aurora visuals, agent status indicators, streamed markdown rendering, and conversation/session persistence on the frontend

## Testing
- `python -m compileall .`


------
https://chatgpt.com/codex/tasks/task_e_68cd6b9c7518832a95892335c1c6688c