### PR TITLE
Add autonomous reasoning pipeline with transparent tool usage

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,9 @@
-import os, json, logging
-from typing import List, TypedDict, Optional
+import os
+import json
+import logging
+import textwrap
+from pathlib import Path
+from typing import Any, Dict, List, Optional, TypedDict, Literal
 
 try:
     import requests
@@ -14,11 +18,361 @@ from flask import Flask, render_template, request, jsonify
 app = Flask(__name__)
 app.logger.setLevel(logging.INFO)
 
+BASE_DIR = Path(__file__).resolve().parent
+MAX_FILE_CHARS = 4000
+
 # ---------- Models ----------
 class SearchItem(TypedDict):
     title: str
     url: str
     snippet: str
+
+
+class ActionItem(TypedDict, total=False):
+    """Represents a single tool decision."""
+
+    type: Literal["search", "read_file"]
+    reason: str
+    query: str
+    depth: Literal["basic", "advanced"]
+    path: str
+
+
+class ActionPlan(TypedDict):
+    """Structure returned by the reasoning controller."""
+
+    reasoning: List[str]
+    actions: List[ActionItem]
+    respond_directly: bool
+
+
+def _extract_json_object(text: str) -> Dict[str, Any]:
+    """Best-effort extraction of a JSON object from LLM text."""
+
+    if not text:
+        raise ValueError("Empty response")
+
+    text = text.strip()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        candidate = text[start : end + 1]
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            pass
+
+    raise ValueError(f"Could not parse JSON from response: {text[:120]}...")
+
+
+def decide_agent_actions(client: Groq, user_message: str) -> ActionPlan:
+    """Ask the model for a structured plan of action."""
+
+    decision_system_prompt = (
+        "You control Boog's tools. Decide whether to search the web or read files. "
+        "Minimize unnecessary calls while ensuring accuracy. "
+        "Respond with strict JSON using keys reasoning (list of short strings), "
+        "actions (list) and respond_directly (boolean)."
+    )
+
+    tool_description = (
+        "Tools available:\n"
+        "1. search(query, depth) -> Use when the user needs fresh or missing knowledge. "
+        "Return at most two search actions. Depth is 'basic' by default; choose 'advanced' "
+        "only if essential.\n"
+        "2. read_file(path) -> Use for repository files when explicitly needed. Paths must be "
+        "relative to the project root, no parent-directory traversals, max three files."
+    )
+
+    decision_prompt = (
+        f"User message:\n{user_message}\n\n"
+        f"{tool_description}\n\n"
+        "Return JSON shaped as:\n"
+        "{\n"
+        "  \"reasoning\": [\"step 1\", \"step 2\"],\n"
+        "  \"actions\": [\n"
+        "    {\"type\": \"search\", \"query\": \"...\", \"reason\": \"...\", \"depth\": \"basic\"},\n"
+        "    {\"type\": \"read_file\", \"path\": \"README.md\", \"reason\": \"...\"}\n"
+        "  ],\n"
+        "  \"respond_directly\": true\n"
+        "}\n\n"
+        "If no tools are required, return an empty actions list and set respond_directly true."
+    )
+
+    response = client.chat.completions.create(
+        model="openai/gpt-oss-120b",
+        temperature=0.2,
+        messages=[
+            {"role": "system", "content": decision_system_prompt},
+            {"role": "user", "content": decision_prompt},
+        ],
+    )
+
+    data = _extract_json_object(response.choices[0].message.content or "")
+
+    reasoning = [str(item).strip() for item in data.get("reasoning", []) if str(item).strip()]
+    actions: List[ActionItem] = []
+    for raw in data.get("actions", []):
+        if not isinstance(raw, dict):
+            continue
+        action_type = str(raw.get("type", "")).strip().lower()
+        reason = str(raw.get("reason", "")).strip()
+        if action_type == "search":
+            query = str(raw.get("query", "")).strip()
+            if not query:
+                continue
+            depth = str(raw.get("depth", "basic")).strip().lower()
+            depth = "advanced" if depth == "advanced" else "basic"
+            actions.append(
+                ActionItem(
+                    type="search",
+                    reason=reason or "Investigate via web search.",
+                    query=query,
+                    depth=depth,
+                )
+            )
+        elif action_type == "read_file":
+            path = str(raw.get("path", "")).strip()
+            if not path:
+                continue
+            actions.append(
+                ActionItem(
+                    type="read_file",
+                    reason=reason or "Inspect repository file for details.",
+                    path=path,
+                )
+            )
+
+    # Enforce tool limits to keep costs predictable.
+    search_actions = [a for a in actions if a["type"] == "search"][:2]
+    file_actions = [a for a in actions if a["type"] == "read_file"][:3]
+    actions = search_actions + file_actions
+
+    respond_directly = bool(data.get("respond_directly", not actions))
+
+    if not reasoning:
+        reasoning = [
+            "Analyzed the user's intent to decide whether external information is needed.",
+        ]
+
+    return ActionPlan(
+        reasoning=reasoning,
+        actions=actions,
+        respond_directly=respond_directly,
+    )
+
+
+def safe_read_file(path: str, *, max_chars: int = MAX_FILE_CHARS) -> str:
+    """Safely read a repository file and return a trimmed excerpt."""
+
+    normalized = path.strip()
+    if not normalized:
+        raise ValueError("Empty file path")
+
+    if ".." in Path(normalized).parts:
+        raise ValueError("Parent directory references are not allowed")
+
+    target = (BASE_DIR / normalized).resolve()
+    if not target.is_file():
+        raise ValueError("File not found")
+
+    if BASE_DIR not in target.parents and target != BASE_DIR:
+        raise ValueError("Path outside project scope")
+
+    content = target.read_text(encoding="utf-8", errors="ignore")
+
+    if len(content) > max_chars:
+        return content[:max_chars] + "\n… [truncated]"
+    return content
+
+
+def execute_actions(plan: ActionPlan) -> Dict[str, Any]:
+    """Run tool actions decided by the controller."""
+
+    action_logs: List[str] = []
+    search_outputs: List[Dict[str, Any]] = []
+    file_outputs: List[Dict[str, str]] = []
+
+    for action in plan["actions"]:
+        if action["type"] == "search":
+            query = action.get("query", "")
+            depth = action.get("depth", "basic")
+            try:
+                results = tavily_search(query, k=4, depth=depth)
+                search_outputs.append({
+                    "query": query,
+                    "depth": depth,
+                    "reason": action.get("reason", ""),
+                    "results": results,
+                })
+                action_logs.append(
+                    f"Web search executed for '{query}' (depth: {depth})."
+                )
+            except Exception as exc:  # pragma: no cover - network errors
+                app.logger.error("Tavily search failed: %s", exc)
+                action_logs.append(
+                    f"Web search for '{query}' failed: {exc}."
+                )
+        elif action["type"] == "read_file":
+            path = action.get("path", "")
+            try:
+                content = safe_read_file(path)
+                snippet = content[:1600]
+                if len(content) > 1600:
+                    snippet += "\n… [truncated]"
+                file_outputs.append({
+                    "path": path,
+                    "reason": action.get("reason", ""),
+                    "content": snippet,
+                })
+                action_logs.append(f"Read file '{path}'.")
+            except Exception as exc:
+                app.logger.error("File read failed: %s", exc)
+                action_logs.append(
+                    f"Could not read file '{path}': {exc}."
+                )
+
+    return {
+        "search_outputs": search_outputs,
+        "file_outputs": file_outputs,
+        "action_logs": action_logs,
+    }
+
+
+def _format_context(search_outputs: List[Dict[str, Any]], file_outputs: List[Dict[str, str]]) -> str:
+    """Prepare context notes for the response synthesizer."""
+
+    blocks: List[str] = []
+
+    for idx, block in enumerate(search_outputs, 1):
+        label = f"search-{idx}"
+        lines = [
+            f"{label}: query='{block['query']}' depth='{block['depth']}' reason='{block.get('reason', '')}'"
+        ]
+        for jdx, result in enumerate(block["results"], 1):
+            snippet = textwrap.shorten(result["snippet"], width=360, placeholder="…")
+            lines.append(
+                f"{label}.{jdx}: title='{result['title']}' url='{result['url']}' snippet='{snippet}'"
+            )
+        blocks.append("\n".join(lines))
+
+    for idx, block in enumerate(file_outputs, 1):
+        label = f"file-{idx}"
+        excerpt = textwrap.shorten(block["content"], width=360, placeholder="…")
+        blocks.append(
+            f"{label}: path='{block['path']}' reason='{block.get('reason', '')}'\n{excerpt}"
+        )
+
+    return "\n\n".join(blocks) if blocks else "(no external context used)"
+
+
+def synthesize_final_answer(
+    client: Groq,
+    user_message: str,
+    plan: ActionPlan,
+    search_outputs: List[Dict[str, Any]],
+    file_outputs: List[Dict[str, str]],
+) -> str:
+    """Ask the LLM to write the final response using gathered context."""
+
+    reasoning_summary = "\n".join(
+        f"Step {idx + 1}: {text}" for idx, text in enumerate(plan["reasoning"])
+    )
+    context_blob = _format_context(search_outputs, file_outputs)
+
+    synthesis_prompt = (
+        "You are Boog, an aligned assistant. Use the provided context if it exists. "
+        "Cite web search evidence using (search-1), (search-1.2) etc. Cite file excerpts as (file-1). "
+        "If context is missing, respond from prior knowledge but note any uncertainty."
+    )
+
+    user_payload = (
+        f"User message:\n{user_message}\n\n"
+        f"Internal reasoning summary:\n{reasoning_summary or 'n/a'}\n\n"
+        f"Context:\n{context_blob}\n\n"
+        "Draft a clear, structured answer."
+    )
+
+    result = client.chat.completions.create(
+        model="openai/gpt-oss-120b",
+        temperature=0.4,
+        messages=[
+            {"role": "system", "content": synthesis_prompt},
+            {"role": "user", "content": user_payload},
+        ],
+    )
+
+    return (result.choices[0].message.content or "").strip() or "(No response generated.)"
+
+
+def build_transparent_response(
+    plan: ActionPlan,
+    action_logs: List[str],
+    final_answer: str,
+    search_outputs: List[Dict[str, Any]],
+) -> str:
+    """Compose the final markdown sent to the UI with reasoning transparency."""
+
+    sections: List[str] = []
+
+    if plan["reasoning"]:
+        reasoning_lines = "\n".join(
+            f"{idx + 1}. {line}" for idx, line in enumerate(plan["reasoning"])
+        )
+        sections.append(f"### Reasoning Workflow\n{reasoning_lines}")
+
+    if action_logs:
+        log_lines = "\n".join(f"- {log}" for log in action_logs)
+        sections.append(f"### Tool Actions\n{log_lines}")
+    else:
+        sections.append(
+            "### Tool Actions\n- No external tools were executed for this turn."
+        )
+
+    sections.append(f"### Final Answer\n{final_answer}")
+
+    if search_outputs:
+        link_lines: List[str] = []
+        for idx, block in enumerate(search_outputs, 1):
+            label = f"search-{idx}"
+            for jdx, result in enumerate(block["results"], 1):
+                title = result["title"] or result["url"] or "(untitled)"
+                link_lines.append(
+                    f"- ({label}.{jdx}) [{title}]({result['url']})"
+                )
+        if link_lines:
+            sections.append("### Sources\n" + "\n".join(link_lines))
+
+    return "\n\n".join(sections)
+
+
+def run_agent(user_message: str) -> str:
+    client = _groq()
+    if not client:
+        return "GROQ_API_KEY is not set on the server – AI mode is unavailable."
+
+    plan = decide_agent_actions(client, user_message)
+    execution = execute_actions(plan)
+
+    final_answer = synthesize_final_answer(
+        client,
+        user_message,
+        plan,
+        execution["search_outputs"],
+        execution["file_outputs"],
+    )
+
+    return build_transparent_response(
+        plan,
+        execution["action_logs"],
+        final_answer,
+        execution["search_outputs"],
+    )
 
 # ---------- HTTP helper ----------
 def _post_json(url: str, headers: dict, payload: dict) -> dict:
@@ -140,16 +494,15 @@ def index():
 def chat():
     payload = request.get_json(silent=True) or {}
     user_input: str = (payload.get("message") or "").strip()
-    mode: str = (payload.get("mode") or "ai").lower()  # "ai" | "web"
 
     if not user_input:
         return jsonify(response="Please provide a message.")
 
-    if mode in ("web", "web-search", "search"):
-        # You can flip to depth="advanced" for tougher queries (costs 2 credits).
-        resp = answer_with_web_search(user_input, k=5, depth="basic")
-    else:
-        resp = generate_ai_response(user_input)
+    try:
+        resp = run_agent(user_input)
+    except Exception as exc:  # pragma: no cover - defensive
+        app.logger.exception("Agent pipeline error: %s", exc)
+        resp = "An internal error occurred while generating a response. Please try again."
 
     return jsonify(response=resp)
 

--- a/static/boog.css
+++ b/static/boog.css
@@ -116,33 +116,6 @@ h1 { font-size: 3rem; font-weight: 700; color: var(--text-main); margin-bottom: 
 }
 .input-bar input::placeholder{color:var(--text-secondary);font-weight:300}
 
-/* Mode button (magnifying glass) */
-.mode-button {
-  display: inline-flex; align-items: center; justify-content: center;
-  width: 40px; height: 40px;
-  border-radius: 50%;
-  border: 1.5px solid var(--border-color);
-  background: transparent;
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: all .2s ease;
-  position: relative;
-}
-.mode-button:hover { color: var(--text-main); border-color: var(--accent); box-shadow: 0 4px 12px rgba(99,102,241,.15); transform: translateY(-1px); }
-.mode-button:active { transform: translateY(0); }
-.mode-button.active {
-  background: var(--accent);
-  color: #fff;
-  border-color: var(--accent);
-  box-shadow: 0 6px 16px rgba(99,102,241,.35);
-}
-.mode-badge {
-  position: absolute; bottom: -6px; right: -6px;
-  padding: 2px 6px; border-radius: 10px; font-size: .65rem; font-weight: 600;
-  background: var(--accent); color: #fff; display: none;
-}
-.mode-button.active .mode-badge { display: inline-block; }
-
 .send-button {
   display:flex;align-items:center;justify-content:center;
   width:40px;height:40px;padding:0;background:var(--accent);color:#fff;border:none;border-radius:50%;

--- a/templates/index.html
+++ b/templates/index.html
@@ -55,26 +55,11 @@
       <input
         type="text"
         id="message"
-        placeholder="Type your message..."
+        placeholder="Type your message… (Boog decides on tools automatically)"
         autocomplete="off"
         aria-label="Message input"
         maxlength="1000"
       />
-
-      <!-- Magnifying glass toggle -->
-      <button
-        id="webToggle"
-        class="mode-button"
-        type="button"
-        title="Toggle Web Search mode (Alt+W)"
-        aria-label="Toggle Web Search mode"
-        aria-pressed="false"
-      >
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M10 3.5a6.5 6.5 0 1 1 0 13 6.5 6.5 0 0 1 0-13Zm0-1.5a8 8 0 0 0-6.32 12.9l-2.59 2.6a1 1 0 1 0 1.42 1.4l2.58-2.58A8 8 0 1 0 10 2Z"/>
-        </svg>
-        <span class="mode-badge" aria-hidden="true">WS</span>
-      </button>
 
       <button
         id="sendBtn"
@@ -96,33 +81,11 @@
     const chat = document.getElementById('chat');
     const messageInput = document.getElementById('message');
     const sendBtn = document.getElementById('sendBtn');
-    const webToggle = document.getElementById('webToggle');
 
     let isTyping = false;
-    let currentMode = 'ai'; // default
-
-    document.addEventListener('keydown', (e) => {
-      if (e.altKey && (e.key === 'w' || e.key === 'W')) {
-        e.preventDefault();
-        toggleWebMode();
-      }
-    });
 
     sendBtn.addEventListener('click', sendMessage);
     messageInput.addEventListener('keydown', handleKeyPress);
-    webToggle.addEventListener('click', toggleWebMode);
-
-    function toggleWebMode() {
-      const isActive = webToggle.classList.toggle('active');
-      webToggle.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-      currentMode = isActive ? 'web-search' : 'ai';
-      messageInput.placeholder = isActive
-        ? 'Search the web… (Alt+W to switch back)'
-        : 'Type your message…';
-      webToggle.title = isActive
-        ? 'Web Search: ON (Alt+W to turn off)'
-        : 'Toggle Web Search mode (Alt+W)';
-    }
 
     function handleKeyPress(e) {
       if (e.key === 'Enter' && !e.shiftKey) {
@@ -207,7 +170,6 @@
       sendBtn.disabled = loading;
       sendBtn.classList.toggle('loading', loading);
       messageInput.disabled = loading;
-      webToggle.disabled = loading;
       if (loading) {
         sendBtn.setAttribute('aria-label', 'Sending message...');
       } else {
@@ -236,7 +198,7 @@
         const response = await fetch('/chat', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ message, mode: currentMode })
+          body: JSON.stringify({ message })
         });
 
         if (!response.ok) throw new Error('Network response was not ok');
@@ -255,7 +217,9 @@
     }
 
     window.addEventListener('load', () => {
-      setTimeout(() => { appendBotMessage('Hey there! I\'m Boog!'); }, 500);
+      setTimeout(() => {
+        appendBotMessage('Hey there! I\'m Boog! I\'ll decide when to search the web or read project files to help you best.');
+      }, 500);
     });
 
     messageInput.addEventListener('input', function () {


### PR DESCRIPTION
## Summary
- add a Groq-driven controller that plans tool usage, executes searches or file reads, and builds transparent responses
- provide safe repository file reading support and contextual synthesis for the final reply
- update the chat UI to reflect automatic tool decisions and simplify the input controls

## Testing
- python -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_e_6900e7eef2ac832ab872ecb979690b29