### PR TITLE
Enhance landing UI

### DIFF
--- a/static/boog.css
+++ b/static/boog.css
@@ -51,15 +51,216 @@ body::before {
   z-index: -1;
 }
 
-.container {
-  width: 100%; max-width: 700px; margin: 0 auto;
-  padding: 2rem 1.5rem 9rem;
-  flex: 1; display: flex; flex-direction: column; position: relative;
+.background-shapes {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
 }
 
-.header { text-align: center; margin-bottom: 2rem; animation: fadeInUp 0.8s ease-out; }
-h1 { font-size: 3rem; font-weight: 700; color: var(--text-main); margin-bottom: 0.5rem; text-shadow: 0 2px 10px rgba(0,0,0,.1); }
-.subtitle { color: var(--text-secondary); font-size: 1.1rem; font-weight: 300; margin-bottom: 1.5rem; }
+.shape {
+  position: absolute;
+  opacity: 0.35;
+  transform: translate3d(0, 0, 0);
+}
+
+.shape-one {
+  width: 220px;
+  height: 220px;
+  top: 5%;
+  left: 10%;
+  background: radial-gradient(circle, #f472b6 0%, transparent 70%);
+  animation: float 12s ease-in-out infinite;
+}
+
+.shape-two {
+  width: 300px;
+  height: 300px;
+  right: -10%;
+  top: 15%;
+  background: radial-gradient(circle, #34d399 0%, transparent 70%);
+  animation: float 14s ease-in-out infinite reverse;
+}
+
+.shape-three {
+  width: 200px;
+  height: 200px;
+  bottom: 10%;
+  left: -5%;
+  background: radial-gradient(circle, #60a5fa 0%, transparent 70%);
+  animation: float 16s ease-in-out infinite;
+}
+
+@keyframes float {
+  0% { transform: translateY(0) scale(1); }
+  50% { transform: translateY(-20px) scale(1.05); }
+  100% { transform: translateY(0) scale(1); }
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 9rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  gap: 1.5rem;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  animation: fadeInUp 0.8s ease-out;
+}
+
+.hero-card {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 32px;
+  padding: 2rem;
+  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  -webkit-backdrop-filter: blur(24px);
+  backdrop-filter: blur(24px);
+}
+
+@media (prefers-color-scheme: dark) {
+  .hero-card {
+    background: rgba(17, 24, 39, 0.9);
+    border-color: rgba(255, 255, 255, 0.08);
+  }
+}
+
+.hero-badge {
+  display: inline-flex;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.1);
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  margin-bottom: 0.75rem;
+}
+
+h1 {
+  font-size: clamp(2.25rem, 5vw, 3.25rem);
+  font-weight: 700;
+  color: var(--text-main);
+  margin-bottom: 0.5rem;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.subtitle {
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  font-weight: 400;
+  margin-bottom: 1.25rem;
+  line-height: 1.6;
+}
+
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.status-card {
+  padding: 1rem 1.25rem;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  -webkit-backdrop-filter: blur(18px);
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow);
+}
+
+@media (prefers-color-scheme: dark) {
+  .status-card {
+    background: rgba(31, 41, 55, 0.85);
+    border-color: rgba(255, 255, 255, 0.08);
+  }
+}
+
+.status-label {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  color: var(--text-secondary);
+  margin-bottom: 0.35rem;
+}
+
+.status-value {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--text-main);
+  font-size: 1.05rem;
+}
+
+.status-card p {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 12px rgba(99, 102, 241, 0.8);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+#modeStatus[data-mode='web'] .status-dot {
+  background: #f59e0b;
+  box-shadow: 0 0 12px rgba(245, 158, 11, 0.8);
+}
+
+.status-chip {
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  font-size: 0.85rem;
+  color: var(--accent);
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.status-tips span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  font-size: 0.9rem;
+}
+
+.status-tips kbd {
+  padding: 0.15rem 0.4rem;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.08);
+  font-size: 0.75rem;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  .status-tips kbd {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.08);
+  }
+}
 
 #chat { flex: 1; display: flex; flex-direction: column; gap: 1rem; overflow-y: auto; padding-right: .5rem; scroll-behavior: smooth; }
 #chat::-webkit-scrollbar { width: 6px; }
@@ -116,6 +317,59 @@ h1 { font-size: 3rem; font-weight: 700; color: var(--text-main); margin-bottom: 
 }
 .input-bar input::placeholder{color:var(--text-secondary);font-weight:300}
 
+.quick-actions {
+  width: 100%;
+  max-width: 900px;
+  margin: 0 auto 1.5rem;
+  padding: 0 1.5rem;
+}
+
+.quick-title {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.45rem;
+  font-weight: 500;
+}
+
+.quick-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.quick-pill {
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--text-main);
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: var(--shadow);
+}
+
+.quick-pill:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 30px rgba(0, 0, 0, 0.15);
+}
+
+@media (prefers-color-scheme: dark) {
+  .quick-pill {
+    background: rgba(17, 24, 39, 0.85);
+    border-color: rgba(255, 255, 255, 0.1);
+    color: var(--text-main);
+  }
+}
+
+.footer-note {
+  text-align: center;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  margin-top: 0.5rem;
+  padding-bottom: 2rem;
+}
+
 /* Mode button (magnifying glass) */
 .mode-button {
   display: inline-flex; align-items: center; justify-content: center;
@@ -159,6 +413,8 @@ h1 { font-size: 3rem; font-weight: 700; color: var(--text-main); margin-bottom: 
 
 @media (max-width:768px){
   .container{padding:1.5rem 1rem 8rem;max-width:100%}
+  .hero-card{padding:1.5rem}
+  .status-grid{grid-template-columns:1fr}
   h1{font-size:2.5rem}
   .msg{max-width:90%;padding:.875rem 1.25rem}
 }
@@ -167,6 +423,7 @@ h1 { font-size: 3rem; font-weight: 700; color: var(--text-main); margin-bottom: 
   h1{font-size:2rem}
   .msg{max-width:95%;padding:.75rem 1rem}
   .input-container{padding:1rem}
+  .quick-actions{padding:0 1rem}
 }
 
 *:focus { outline: 2px solid var(--accent); outline-offset: 2px; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,20 +34,70 @@
 <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" async></script>
 
 <body>
+  <div class="background-shapes" aria-hidden="true">
+    <span class="shape shape-one"></span>
+    <span class="shape shape-two"></span>
+    <span class="shape shape-three"></span>
+  </div>
+
   <div class="container">
     <div class="header">
-      <h1>Boog 😼</h1>
-      <p class="subtitle">
-        A cat-themed AI agent with advanced search and complex problem-solving capabilities
-        developed by
-        <a href="https://github.com/robitec97" target="_blank" rel="noopener noreferrer" aria-label="Visit Roberto Pillitteri’s GitHub profile">
-          Roberto Pillitteri
-        </a>
-      </p>
-      <!-- Mode selector removed -->
+      <div class="hero-card">
+        <div class="hero-badge">Boog v2 • Real-time</div>
+        <h1>Boog 😼</h1>
+        <p class="subtitle">
+          A cat-themed AI agent with advanced search and complex problem-solving capabilities
+          developed by
+          <a href="https://github.com/robitec97" target="_blank" rel="noopener noreferrer" aria-label="Visit Roberto Pillitteri’s GitHub profile">
+            Roberto Pillitteri
+          </a>
+        </p>
+        <div class="hero-meta" role="list">
+          <span role="listitem">⚡ Groq accelerated</span>
+          <span role="listitem">🌐 Web aware</span>
+          <span role="listitem">🧮 MathJax ready</span>
+        </div>
+      </div>
+
+      <div class="status-grid" aria-label="Boog status panel">
+        <div class="status-card">
+          <div class="status-label">Current mode</div>
+          <div class="status-value" id="modeStatus" data-mode="ai">
+            <span class="status-dot" aria-hidden="true"></span>
+            <span id="modeLabel">AI chat</span>
+          </div>
+          <p>Use Groq for fast, grounded reasoning.</p>
+        </div>
+        <div class="status-card">
+          <div class="status-label">Search boost</div>
+          <div class="status-value">
+            <span class="status-chip">Tavily</span>
+            <span class="status-chip">Citations</span>
+          </div>
+          <p>Web answers come with clickable links.</p>
+        </div>
+        <div class="status-card">
+          <div class="status-label">Session tips</div>
+          <div class="status-value status-tips">
+            <span>Press <kbd>Alt</kbd> + <kbd>W</kbd></span>
+            <span>Enter to send</span>
+          </div>
+          <p>Toggle web mode or send without touching the mouse.</p>
+        </div>
+      </div>
     </div>
 
     <div id="chat" role="log" aria-live="polite" aria-label="Chat messages"></div>
+  </div>
+
+  <div class="quick-actions" aria-label="Suggested prompts">
+    <p class="quick-title">Try asking Boog…</p>
+    <div class="quick-list">
+      <button class="quick-pill" type="button" data-prompt="Summarize the latest AI safety research in bullet points.">AI safety roundup</button>
+      <button class="quick-pill" type="button" data-prompt="Plan a 3-day foodie trip to Osaka with daily highlights." data-send="true">Travel planning</button>
+      <button class="quick-pill" type="button" data-prompt="Explain how transformers work to a curious teenager.">Explain transformers</button>
+      <button class="quick-pill" type="button" data-prompt="Find the most cited sources on ocean plastic pollution and cite them." data-send="true">Source hunt</button>
+    </div>
   </div>
 
   <div class="input-container">
@@ -89,6 +139,8 @@
     </div>
   </div>
 
+  <p class="footer-note">Boog respects your keys and never stores conversations. Stay curious! 🐾</p>
+
   <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/9.1.2/marked.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.5/purify.min.js"></script>
 
@@ -97,6 +149,9 @@
     const messageInput = document.getElementById('message');
     const sendBtn = document.getElementById('sendBtn');
     const webToggle = document.getElementById('webToggle');
+    const modeLabel = document.getElementById('modeLabel');
+    const modeStatus = document.getElementById('modeStatus');
+    const quickPrompts = document.querySelectorAll('[data-prompt]');
 
     let isTyping = false;
     let currentMode = 'ai'; // default
@@ -111,6 +166,16 @@
     sendBtn.addEventListener('click', sendMessage);
     messageInput.addEventListener('keydown', handleKeyPress);
     webToggle.addEventListener('click', toggleWebMode);
+    quickPrompts.forEach(btn => {
+      btn.addEventListener('click', () => {
+        messageInput.value = btn.dataset.prompt || '';
+        messageInput.focus();
+        messageInput.dispatchEvent(new Event('input'));
+        if (btn.dataset.send === 'true') {
+          sendMessage();
+        }
+      });
+    });
 
     function toggleWebMode() {
       const isActive = webToggle.classList.toggle('active');
@@ -122,6 +187,8 @@
       webToggle.title = isActive
         ? 'Web Search: ON (Alt+W to turn off)'
         : 'Toggle Web Search mode (Alt+W)';
+      modeLabel.textContent = isActive ? 'Web search' : 'AI chat';
+      modeStatus.dataset.mode = isActive ? 'web' : 'ai';
     }
 
     function handleKeyPress(e) {


### PR DESCRIPTION
## Summary
- add a hero card, status grid, and suggested prompt quick actions to the chat landing page for a richer UX
- extend the styling with animated background shapes, new layout cards, and responsive tweaks
- wire quick action buttons and mode indicator updates into the existing client-side logic

## Testing
- python -m compileall app.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dda2525f8832ab4d42f95dc68332b)